### PR TITLE
Return the observation as correct object

### DIFF
--- a/CybORG/CybORG/Evaluation/evaluation.py
+++ b/CybORG/CybORG/Evaluation/evaluation.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
                 # cyborg.env.env.tracker.render()
                 for j in range(num_steps):
                     action = agent.get_action(observation, action_space)
-                    obs, rew, done, info = wrapped_cyborg.step(action)
+                    observation, rew, done, info = wrapped_cyborg.step(action)
                     # result = cyborg.step(agent_name, action)
                     r.append(rew)
                     # r.append(result.reward)


### PR DESCRIPTION
The evaluation.py file was returning the observation in the object `obs` but the agent was being given the object `observation` leading to poor scoring in the evaluation